### PR TITLE
docs: highlight community support resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Learn about GoodData.UI:
 -   [📊 Examples Gallery](https://gdui-examples.herokuapp.com)
 -   [⚙️ API reference](https://sdk.gooddata.com/gooddata-ui-apidocs/docs/index.html)
 
+## Community and support
+
+If you have questions while exploring the SDK, start with the [GoodData Community Slack](https://www.gooddata.com/slack) where the engineering team and fellow builders share tips. The [GitHub Discussions](https://github.com/gooddata/gooddata-ui-sdk/discussions) board is also a great place to search for previously answered questions or to propose new ideas for the roadmap.
+
 ## Package overview
 
 The most notable packages in this monorepo

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Learn about GoodData.UI:
 
 ## Community and support
 
-If you have questions while exploring the SDK, start with the [GoodData Community Slack](https://www.gooddata.com/slack) where the engineering team and fellow builders share tips. The [GitHub Discussions](https://github.com/gooddata/gooddata-ui-sdk/discussions) board is also a great place to search for previously answered questions or to propose new ideas for the roadmap.
+No matter where you are on your GoodData.UI journey, there is a place to ask questions and share feedback:
+
+-   [💬 Community Slack](https://www.gooddata.com/slack) – Chat with GoodData engineers and community builders in real time.
+-   [🧠 GitHub Discussions](https://github.com/gooddata/gooddata-ui-sdk/discussions) – Browse previous answers or start a new thread with ideas and how-to questions.
+-   [🛟 GoodData Support Portal](https://support.gooddata.com/hc/en-us) – File a ticket with the GoodData Support team if you are an enterprise customer and need hands-on help.
 
 ## Package overview
 


### PR DESCRIPTION
## Summary
- add a new "Community and support" section to the main README
- point readers to Slack and GitHub Discussions for questions and ideas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d523a04fdc832cbfa1ba078e48a2a3